### PR TITLE
Require engine and version from introjs-rails.rb

### DIFF
--- a/lib/introjs-rails.rb
+++ b/lib/introjs-rails.rb
@@ -1,0 +1,2 @@
+require 'introjs-rails/engine'
+require 'introjs-rails/version'


### PR DESCRIPTION
I couldn't make the JS and CSS files visible to the Rails app without requiring the Engine from introjs-rails.rb
