### PR TITLE
Enable Rails 6 compatibility

### DIFF
--- a/introjs-rails.gemspec
+++ b/introjs-rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency "thor", "~> 0.14"
+  s.add_dependency "thor", ">= 0.14"
   s.add_runtime_dependency "sass-rails", ">= 3.2"
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "rails", "> 3.0", "< 5"

--- a/lib/introjs-rails/source_file.rb
+++ b/lib/introjs-rails/source_file.rb
@@ -13,6 +13,7 @@ class SourceFile < Thor
     remote = "https://github.com/usablica/intro.js"
     get "#{remote}/raw/#{tag}/minified/intro.min.js", "javascripts/introjs.js"
     get "#{remote}/raw/#{tag}/minified/introjs.min.css", "stylesheets/introjs.css"
+    get "#{remote}/raw/#{tag}/minified/introjs-rtl.min.css", "stylesheets/introjs-rtl.css"
   end
 
   private


### PR DESCRIPTION
**Situation:**
Presently introjs-rails will only work up to Rails 5, and cannot be installed on Rails 6 due to a pessimistic dependency on `thor ~>0.14`.  

**Background:**
The official [introjs](https://introjs.com/docs/wrappers/rails) documentation still points to this gem, but the gem hasn't been updated in almost 8 years (since May 18 2015).

**Assessment:**
The current gem shows the following error due to the block.
    
    Could not find compatible versions
    Because every version of introjs-rails depends on thor ~> 0.14
      and railties >= 6.1.7 depends on thor ~> 1.0,
      every version of introjs-rails is incompatible with railties >= 6.1.7.
    And because rails >= 6.1.7, < 7.0.4.3 depends on railties = 6.1.7,
      every version of introjs-rails is incompatible with rails >= 6.1.7, < 7.0.4.3.
    So, because Gemfile depends on rails ~> 6.1.7
      and Gemfile depends on introjs-rails >= 0,
      version solving has failed.

Smoke testing shows relaxing this dependency constraint and updating the source file works (only personal project tested), and presumably works for the author of these two CR's (@ahaikal).

**Recommendation:**
Merge the two CR's into the official repo, and (ideally) generate a new release of nodejs-rails (as 1.0.1).

**Alternatives Considered:**
1. Forking a copy of ahaikal's fix and not contributing back to the primary repo. Not recommended since this fix is valuable to others.
2. Pointing the introjs documentation for rails at ahaikal's repo, and forcing folks to use github references in their gemfiles. Not recommended since this seems unnecessary and awkward.
3. Removing introjs-rails from my project because it's not maintained. Not ideal since there's a workable solution here.

P.S., this is my first pull request on an OSS project, and it's a request for pulling someone else's CR's. Feedback welcome.